### PR TITLE
Suggested changes to use of fieldset and legend in the Captions Settings

### DIFF
--- a/src/css/components/_captions-settings.scss
+++ b/src/css/components/_captions-settings.scss
@@ -6,7 +6,7 @@
   color: $primary-foreground-color;
   margin: 0 auto;
   padding: 0.5em;
-  height: 20em;
+  height: 15em;
   font-size: 12px;
   width: 40em;
 }
@@ -40,8 +40,9 @@
   margin: 5px;
   padding: 3px;
   min-height: 40px;
+  border: none;
 }
-.vjs-caption-settings .vjs-tracksetting label {
+.vjs-caption-settings .vjs-tracksetting label, legend {
   display: block;
   width: 100px;
   margin-bottom: 5px;
@@ -50,6 +51,8 @@
 .vjs-caption-settings .vjs-tracksetting span {
   display: inline;
   margin-left: 5px;
+  vertical-align: top;
+  float: right;
 }
 
 .vjs-caption-settings .vjs-tracksetting > div {
@@ -67,24 +70,21 @@
   margin-right: 10px;
 }
 
-.vjs-caption-settings .hiddenReadable {
-  position:absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;  
-}
-
 .vjs-caption-settings fieldset {
   margin-top: 1em;
   margin-left: .5em;
 }
 
-.vjs-caption-settings h2 {
-  margin-bottom: 0;
-  margin-left: .5em;
+// Hide labels within fieldsets, so they are only for screen reader users
+.vjs-caption-settings fieldset .vjs-label {
+  position:absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }
+
 .vjs-caption-settings input[type="button"] {
   width: 40px;
   height: 40px;

--- a/src/js/tracks/text-track-settings.js
+++ b/src/js/tracks/text-track-settings.js
@@ -5,6 +5,7 @@ import Component from '../component';
 import * as Events from '../utils/events.js';
 import * as Fn from '../utils/fn.js';
 import log from '../utils/log.js';
+import * as Guid from '../utils/guid.js';
 import safeParseTuple from 'safe-json-parse/tuple';
 import window from 'global/window';
 
@@ -37,7 +38,7 @@ class TextTrackSettings extends Component {
       this.$('.vjs-bg-color > select').selectedIndex = 0;
       this.$('.window-color > select').selectedIndex = 0;
       this.$('.vjs-text-opacity > select').selectedIndex = 0;
-      this.$('.vjs-bg-opacity > select').selectedIndex = 1;
+      this.$('.vjs-bg-opacity > select').selectedIndex = 0;
       this.$('.vjs-window-opacity > select').selectedIndex = 0;
       this.$('.vjs-edge-style select').selectedIndex = 0;
       this.$('.vjs-font-family select').selectedIndex = 0;
@@ -234,112 +235,118 @@ function setSelectedOption(target, value) {
 }
 
 function captionOptionsMenuTemplate() {
-  let template = `<div class="vjs-tracksettings">
-         <div class="vjs-tracksettings-colors">
-          <fieldset>
-            <legend>Colors</legend>
-            <div class="vjs-fg-color vjs-tracksetting">
-              <label class="vjs-label" for="captions-foreground">Foreground</label>
-              <select id="captions-foreground">
-                <option value="#FFF" selected>White</option>
-                <option value="#000">Black</option>
-                <option value="#F00">Red</option>
-                <option value="#0F0">Green</option>
-                <option value="#00F">Blue</option>
-                <option value="#FF0">Yellow</option>
-                <option value="#F0F">Magenta</option>
-                <option value="#0FF">Cyan</option>
+  let uniqueId = Guid.newGUID();
+
+  let template = `<h2>Captions Settings</h2>
+      <div class="vjs-tracksettings">
+        <div class="vjs-tracksettings-colors">
+          <fieldset class="vjs-fg-color vjs-tracksetting">
+            <legend>Text</legend>
+            <label class="vjs-label" for="captions-foreground-color-${uniqueId}">Color</label>
+            <select id="captions-foreground-color-${uniqueId}">
+              <option value="#FFF" selected>White</option>
+              <option value="#000">Black</option>
+              <option value="#F00">Red</option>
+              <option value="#0F0">Green</option>
+              <option value="#00F">Blue</option>
+              <option value="#FF0">Yellow</option>
+              <option value="#F0F">Magenta</option>
+              <option value="#0FF">Cyan</option>
+            </select>
+            <span class="vjs-text-opacity vjs-opacity">
+              <label class="vjs-label" for="captions-foreground-opacity-${uniqueId}">Transparency</label>
+              <select id="captions-foreground-opacity-${uniqueId}">
+                <option value="1" selected>Opaque</option>
+                <option value="0.5">Semi-Opaque</option>
               </select>
-              <span class="vjs-text-opacity vjs-opacity">
-                <select>
-                  <option value="1" selected>Opaque</option>
-                  <option value="0.5">Semi-Opaque</option>
-                </select>
-              </span>
-            </div>
-            <div class="vjs-bg-color vjs-tracksetting">
-              <label class="vjs-label" for="captions-background">Background</label>
-              <select id="captions-background">
-                <option value="#000" selected>Black</option>
-                <option value="#FFF">White</option>
-                <option value="#F00">Red</option>
-                <option value="#0F0">Green</option>
-                <option value="#00F">Blue</option>
-                <option value="#FF0">Yellow</option>
-                <option value="#F0F">Magenta</option>
-                <option value="#0FF">Cyan</option>
+            </span>
+          </fieldset>
+          <fieldset class="vjs-bg-color vjs-tracksetting">
+            <legend>Background</legend>
+            <label class="vjs-label" for="captions-background-color-${uniqueId}">Color</label>
+            <select id="captions-background-color-${uniqueId}">
+              <option value="#000" selected>Black</option>
+              <option value="#FFF">White</option>
+              <option value="#F00">Red</option>
+              <option value="#0F0">Green</option>
+              <option value="#00F">Blue</option>
+              <option value="#FF0">Yellow</option>
+              <option value="#F0F">Magenta</option>
+              <option value="#0FF">Cyan</option>
+            </select>
+            <span class="vjs-bg-opacity vjs-opacity">
+              <label class="vjs-label" for="captions-background-opacity-${uniqueId}">Transparency</label>
+              <select id="captions-background-opacity-${uniqueId}">
+                <option value="1">Opaque</option>
+                <option value="0.75" selected>Mostly Opaque</option>
+                <option value="0.5">Semi-Transparent</option>
+                <option value="0.25" selected>Mostly Transparent</option>
+                <option value="0">Transparent</option>
               </select>
-              <span class="vjs-bg-opacity vjs-opacity">
-                <select>
-                  <option value="1">Opaque</option>
-                  <option value="0.8" selected>80% Opaque</option>
-                  <option value="0.5">Semi-Transparent</option>
-                  <option value="0">Transparent</option>
-                </select>
-              </span>
-            </div>
-            <div class="window-color vjs-tracksetting">
-              <label class="vjs-label" for="captions-window">Window</label>
-              <select id="captions-window">
-                <option value="#000" selected>Black</option>
-                <option value="#FFF">White</option>
-                <option value="#F00">Red</option>
-                <option value="#0F0">Green</option>
-                <option value="#00F">Blue</option>
-                <option value="#FF0">Yellow</option>
-                <option value="#F0F">Magenta</option>
-                <option value="#0FF">Cyan</option>
+            </span>
+          </fieldset>
+          <fieldset class="window-color vjs-tracksetting">
+            <legend>Window</legend>
+            <label class="vjs-label" for="captions-window-color-${uniqueId}">Color</label>
+            <select id="captions-window-color-${uniqueId}">
+              <option value="#000" selected>Black</option>
+              <option value="#FFF">White</option>
+              <option value="#F00">Red</option>
+              <option value="#0F0">Green</option>
+              <option value="#00F">Blue</option>
+              <option value="#FF0">Yellow</option>
+              <option value="#F0F">Magenta</option>
+              <option value="#0FF">Cyan</option>
+            </select>
+            <span class="vjs-window-opacity vjs-opacity">
+              <label class="vjs-label" for="captions-window-opacity-${uniqueId}">Transparency</label>
+              <select id="captions-window-opacity-${uniqueId}">
+                <option value="0" selected>Transparent</option>
+                <option value="0.25" selected>Mostly Transparent</option>
+                <option value="0.5">Semi-Transparent</option>
+                <option value="0.75" selected>Mostly Opaque</option>
+                <option value="1">Opaque</option>
               </select>
-              <span class="vjs-window-opacity vjs-opacity">
-                <select>
-                  <option value="0" selected>Transparent</option>
-                  <option value="0.5">Semi-Transparent</option>
-                  <option value="1">Opaque</option>
-                </select>
-              </span>
-            </div>
+            </span>
           </fieldset>
         </div><!-- vjs-tracksettings -->
         <div class="vjs-tracksettings-font">
-          <fieldset>
-            <legend>Fonts</legend>
-            <div class="vjs-font-percent vjs-tracksetting">
-              <label class="vjs-label" for="captions-font-size">Font Size</label>
-              <select id="captions-font-size">
-                <option value="0.50">50%</option>
-                <option value="0.75">75%</option>
-                <option value="1.00" selected>100%</option>
-                <option value="1.25">125%</option>
-                <option value="1.50">150%</option>
-                <option value="1.75">175%</option>
-                <option value="2.00">200%</option>
-                <option value="3.00">300%</option>
-                <option value="4.00">400%</option>
-              </select>
-            </div> 
-            <div class="vjs-edge-style vjs-tracksetting">
-              <label class="vjs-label" for="captions-edge-style">Text Edge Style</label>
-              <select id="captions-edge-style">
-                <option value="none" selected>None</option>
-                <option value="raised">Raised</option>
-                <option value="depressed">Depressed</option>
-                <option value="uniform">Uniform</option>
-                <option value="dropshadow">Dropshadow</option>
-              </select>        
-            </div>
-            <div class="vjs-font-family vjs-tracksetting">
-              <label class="vjs-label" for="captions-font-family">Font Family</label>
-              <select id="captions-font-family">
-                <option value="proportionalSansSerif" selected>Proportional Sans-Serif</option>
-                <option value="monospaceSansSerif">Monospace Sans-Serif</option>
-                <option value="proportionalSerif">Proportional Serif</option>
-                <option value="monospaceSerif">Monospace Serif</option>
-                <option value="casual">Casual</option>
-                <option value="script">Script</option>
-                <option value="small-caps">Small Caps</option>
-              </select>
-            </div> 
-          </fieldset>
+          <div class="vjs-font-percent vjs-tracksetting">
+            <label class="vjs-label" for="captions-font-size-${uniqueId}">Font Size</label>
+            <select id="captions-font-size-${uniqueId}">
+              <option value="0.50">50%</option>
+              <option value="0.75">75%</option>
+              <option value="1.00" selected>100%</option>
+              <option value="1.25">125%</option>
+              <option value="1.50">150%</option>
+              <option value="1.75">175%</option>
+              <option value="2.00">200%</option>
+              <option value="3.00">300%</option>
+              <option value="4.00">400%</option>
+            </select>
+          </div>
+          <div class="vjs-edge-style vjs-tracksetting">
+            <label class="vjs-label" for="captions-edge-style-${uniqueId}">Text Edge Style</label>
+            <select id="captions-edge-style-${uniqueId}">
+              <option value="none" selected>None</option>
+              <option value="raised">Raised</option>
+              <option value="depressed">Depressed</option>
+              <option value="uniform">Uniform</option>
+              <option value="dropshadow">Dropshadow</option>
+            </select>
+          </div>
+          <div class="vjs-font-family vjs-tracksetting">
+            <label class="vjs-label" for="captions-font-family-${uniqueId}">Font Family</label>
+            <select id="captions-font-family-${uniqueId}">
+              <option value="proportionalSansSerif" selected>Proportional Sans-Serif</option>
+              <option value="monospaceSansSerif">Monospace Sans-Serif</option>
+              <option value="proportionalSerif">Proportional Serif</option>
+              <option value="monospaceSerif">Monospace Serif</option>
+              <option value="casual">Casual</option>
+              <option value="script">Script</option>
+              <option value="small-caps">Small Caps</option>
+            </select>
+          </div>
         </div>
     <div class="vjs-tracksettings-controls">
       <button class="vjs-default-button">Defaults</button>

--- a/test/unit/tracks/text-track-settings.test.js
+++ b/test/unit/tracks/text-track-settings.test.js
@@ -58,7 +58,7 @@ test('should restore default settings', function() {
   }),
   defaultSettings = {
       'backgroundColor': '#000',
-      'backgroundOpacity': '0.8',
+      'backgroundOpacity': '1',
       'color': '#FFF',
       'fontFamily': 'proportionalSansSerif',
       'textOpacity': '1',
@@ -230,10 +230,10 @@ test('should not restore saved settings', function() {
       'backgroundColor': '#FFF',
       'windowColor': '#FFF',
       'fontPercent': 1.25
-    }, 
+    },
     defaultSettings = {
       'backgroundColor': '#000',
-      'backgroundOpacity': '0.8',
+      'backgroundOpacity': '1',
       'color': '#FFF',
       'fontFamily': 'proportionalSansSerif',
       'textOpacity': '1',


### PR DESCRIPTION
I've changed the use of fieldsets and legends to handle the settings in a way that looks a lot like the previous labeling, but works correctly for screen readers (tested JAWS). I've also added other Opacity/Transparency values, as required by FCC.

BUT, the CSS still needs some work (the buttons in the Settings Dialog aren't right), and the tests are broken. Any chance you can look at this?
